### PR TITLE
Add VSCode remote container support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+
+# Ubuntu variant to use as base image (e.g. ubuntu-22.04, ubuntu-20.04, ubuntu-18.04)
+ARG VARIANT="jammy"
+
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+# Hadolint Dockerfile linter version
+ARG HADOLINT_VERSION="2.10.0"
+
+# Install additional packages
+RUN wget --progress=dot:giga -c https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64 --output-document /usr/bin/hadolint \
+ && chmod 755 /usr/bin/hadolint 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/ubuntu
+{
+	"name": "Docker sandbox",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Ubuntu version: jammy / ubuntu-22.04, focal / ubuntu-20.04, bionic /ubuntu-18.04
+		// Use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon.
+		"args": { 
+      "VARIANT": "ubuntu-18.04", 
+      "HADOLINT_VERSION": "2.10.0"
+    }
+	},
+
+  "extensions": [
+    "exiasr.hadolint"
+  ],
+  
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	//"remoteUser": "vscode",
+	"features": {
+		"git": "latest"
+	}
+}


### PR DESCRIPTION
This PR aims at:
- [x] Adding VSCode [remote container](https://code.visualstudio.com/docs/remote/containers) support
- [x] Providing a Docker image with Hadolint support, so that to enforce best practices when writting Dockerfiles  