### PR TITLE
Fix a minor typo in the image URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
             imageURL="ghcr.io/${repositoryName}/${imageTag}"
             
             # Tag temporary image
-            docker tag ${temporaryImageName} ${imageURL}:
+            docker tag ${temporaryImageName} ${imageURL}
 
             # Push tagged image to Github Container Registry
             docker push ${imageURL}


### PR DESCRIPTION
This PR aims at:
- [x] Remove a wrong trailing semi-colon in the Docker image URL 