### PR TITLE
Fix a minor typo

### DIFF
--- a/.github/workflows/clean-workflow-runs.yml
+++ b/.github/workflows/clean-workflow-runs.yml
@@ -35,6 +35,6 @@ jobs:
       - name: Clean up workflow runs
         uses: boredland/action-purge-workflow-runs@main
         with:
-          day-old: "${{ env.DAYS_OLD }}"
+          days-old: "${{ env.DAYS_OLD }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR aims at:
- [x] Fixing a typo in an input parameter (i.e. 'days-old' instead of 'day-old') of the workflow runs cleaning workflow.