### PR TITLE
Enforce Hadolint linting rule DL4001

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -6,5 +6,4 @@
 # See https://github.com/hadolint/hadolint#rules for a list of available rules.
 ignored:
   - DL3008      # warning: Pin versions in apt-get install (i.e. apt-get insall <package>=<version>)
-  - DL4001      # warning: Either use Wget or Curl but not both
   - DL4006      # warning: Set the SHELL option -o pipefail before RUN with a pipe in it


### PR DESCRIPTION
This PR aims at:
- [x] Enforcing [Hadolint](https://github.com/hadolint/hadolint) linting rule [DL4001](https://github.com/hadolint/hadolint/wiki/DL4001), that forces to use either wget or curl, but not both in a Dockerfile